### PR TITLE
ci(automerge): explicit GITHUB_TOKEN permissions for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [labeled, synchronize, opened, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   automerge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit permissions to the auto-merge workflow so that `peter-evans/enable-pull-request-automerge` can enable auto-merge without `Resource not accessible by integration` errors.

Changes:
- Add `permissions` block in `.github/workflows/auto-merge.yml`:
  - `contents: read`
  - `pull-requests: write`

Pre-requisite (repo settings):
- Ensure "Allow auto-merge" is enabled under Settings → Pull Requests.
- The repo's workflow permissions are set to "Read repository contents and packages" with "Allow GitHub Actions to create and approve pull requests" enabled (already confirmed by screenshot).

Once merged, any PR labeled `automerge` will have auto-merge enabled when CI is green.
