### PR TITLE
ci(pub.dev): workflow de publicación automática en releases

### DIFF
--- a/.github/workflows/publish-to-pub-dev.yml
+++ b/.github/workflows/publish-to-pub-dev.yml
@@ -1,0 +1,44 @@
+name: Publish to pub.dev
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ secrets.PUB_CREDENTIALS_JSON != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Configure pub.dev credentials
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.pub-cache
+          echo "${{ secrets.PUB_CREDENTIALS_JSON }}" > ~/.pub-cache/credentials.json
+          chmod 600 ~/.pub-cache/credentials.json
+
+      - name: Dry-run publish
+        run: dart pub publish --dry-run
+
+      - name: Publish to pub.dev
+        run: dart pub publish -f
+
+  missing-secret:
+    if: ${{ secrets.PUB_CREDENTIALS_JSON == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Missing pub.dev secret
+        run: |
+          echo "PUB_CREDENTIALS_JSON no está configurado como secret del repositorio."
+          echo "Por favor, añade el contenido de ~/.pub-cache/credentials.json como un secret llamado PUB_CREDENTIALS_JSON en:"
+          echo "Settings → Secrets and variables → Actions → New repository secret."
+          exit 1


### PR DESCRIPTION
Este PR añade `.github/workflows/publish-to-pub-dev.yml` para publicar el paquete automáticamente en pub.dev cuando se publique un Release (y permite ejecución manual por `workflow_dispatch`).

Detalles:
- Trigger: `release.published` y `workflow_dispatch`.
- Autenticación: usa `secrets.PUB_CREDENTIALS_JSON` (contenido de `~/.pub-cache/credentials.json`).
- Pasos: `dart pub publish --dry-run` y luego `dart pub publish -f`.
- Si falta el secret, falla de forma explícita con mensaje claro.

Acción requerida tras mergear:
1) Ir a Settings → Secrets and variables → Actions → New repository secret.
2) Crear `PUB_CREDENTIALS_JSON` pegando el contenido de `~/.pub-cache/credentials.json` (generado por `dart pub login`).
3) Disparar el workflow manualmente (Actions → Publish to pub.dev → Run workflow) para publicar la versión actual `0.2.0`, o crear un nuevo Release/tag para publicar automáticamente.
