### PR TITLE
ci: add publish-to-pub-dev workflow

### DIFF
--- a/.github/workflows/publish-to-pub-dev.yml
+++ b/.github/workflows/publish-to-pub-dev.yml
@@ -1,0 +1,44 @@
+name: Publish to pub.dev
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ secrets.PUB_CREDENTIALS_JSON != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Configure pub.dev credentials
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.pub-cache
+          echo "${{ secrets.PUB_CREDENTIALS_JSON }}" > ~/.pub-cache/credentials.json
+          chmod 600 ~/.pub-cache/credentials.json
+
+      - name: Dry-run publish
+        run: dart pub publish --dry-run
+
+      - name: Publish to pub.dev
+        run: dart pub publish -f
+
+  missing-secret:
+    if: ${{ secrets.PUB_CREDENTIALS_JSON == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Missing pub.dev secret
+        run: |
+          echo "PUB_CREDENTIALS_JSON no está configurado como secret del repositorio."
+          echo "Por favor, añade el contenido de ~/.pub-cache/credentials.json como un secret llamado PUB_CREDENTIALS_JSON en:"
+          echo "Settings → Secrets and variables → Actions → New repository secret."
+          exit 1


### PR DESCRIPTION
This PR adds an automated workflow to publish the package to pub.dev when a release is published or via manual dispatch.

Highlights:
- Triggers on `release: published` and `workflow_dispatch`.
- Uses `secrets.PUB_CREDENTIALS_JSON` to provision `~/.pub-cache/credentials.json`.
- Runs `dart pub publish --dry-run` and then `dart pub publish -f`.

Follow-up (optional): switch from `echo` to `printf` for multi-line safety.

Once merged, cut a new release (e.g. v0.2.1) to publish automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated GitHub Actions workflow to publish Dart packages to pub.dev.
  - Triggers on new releases and manual runs, performing a dry-run before the actual publish.
  - Utilizes secure credentials handling; provides clear failure feedback if credentials are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->