### PR TITLE
ci: fix dependabot labeler perms

### DIFF
--- a/.github/workflows/dependabot-labeler.yml
+++ b/.github/workflows/dependabot-labeler.yml
@@ -1,24 +1,46 @@
 name: Dependabot labeler and auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - main
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   label-and-automerge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || startsWith(github.event.pull_request.head.ref, 'dependabot/')
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure labels exist (idempotent)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ensure = async (name, color, description) => {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color, description });
+                } else {
+                  core.setFailed(`Failed ensuring label ${name}: ${e.message}`);
+                  throw e;
+                }
+              }
+            };
+            await ensure('dependencies','0366d6','Dependency updates');
+            await ensure('breaking-change','d93f0b','Breaking change');
+            await ensure('automerge','0e8a16','Eligible for automerge');
 
       - name: Label PRs by update type
         uses: actions/github-script@v7


### PR DESCRIPTION
- Switch to pull_request_target for Dependabot PRs so the job runs in base repo context
- Add explicit permissions: issues: write, pull-requests: write (contents: read)
- Ensure required labels exist (dependencies, breaking-change, automerge) idempotently
- Guard job to only run for Dependabot PRs

This should fix 403 unauthorized on label creation in PRs like #14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved automation for dependency update PRs, with consistent labels for updates, breaking changes, and automerge eligibility.
  - Automatically creates missing labels to prevent labeling failures.
  - Expanded coverage to handle more Dependabot-originated PRs.
  - Consolidated permissions for safer, more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->