### PR TITLE
Chore: Prepare v0.6.0 release for pub.dev

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -30,6 +30,10 @@ isar_agent_memory_tests/
 # Test resources (models downloaded on-demand)
 test_resources/
 
+# Internal docs & research papers (exclude from published package)
+docs/
+research_papers/
+
 # Development tools
 tool/
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Used by: **Pocket Cerebro** (SWAL mobile node), **OrionHealth** (clinical assist
 
 ```yaml
 dependencies:
+  # Add the core cognitive memory engine for agentic LLM apps
   isar_agent_memory: ^0.6.0-dev
   isar: ^3.1.0+1
 ```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,9 +32,11 @@ dependencies:
   firebase_core: ^2.24.2
   firebase_database: ^10.4.0
   web_socket_channel: ^2.4.0
+  tflite_flutter: ^0.12.1
   # Add your embedding provider dependencies as needed (e.g., google_generative_ai, openai, etc.)
 
 dev_dependencies:
+  path: ^1.9.1
   flutter_lints: ^6.0.0
   lints: ^6.0.0
   flutter_test:


### PR DESCRIPTION
This chore prepares the `isar_agent_memory` package for the v0.6.0 release on pub.dev. It ensures that the package is correctly packaged, validates all metadata and dependencies, and verifies that `dart pub publish --dry-run` succeeds without hard errors.

Fixes #53

---
*PR created automatically by Jules for task [6267581771664439442](https://jules.google.com/task/6267581771664439442) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Quickstart dependency example with an explanatory comment for improved setup clarity.

- **Chores**
  - Added TensorFlow Lite support to the project’s package dependencies.
  - Added a development utility dependency to support project tooling.
  - Excluded internal documentation and research materials from published package contents, keeping releases focused on distributable resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->