### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.gitcore/features.json
+++ b/.gitcore/features.json
@@ -20,7 +20,7 @@
   {"id": "privacy", "name": "Privacy features (PII, differential privacy)", "progress_pct": 100, "priority": "P2"},
   {"id": "legacy-pipeline", "name": "Legacy streaming pipeline (backward compat)", "progress_pct": 100, "priority": "P2"},
   {"id": "maintenance", "name": "Memory maintenance service", "progress_pct": 100, "priority": "P2"},
-  {"id": "ci-cd", "name": "CI/CD pipeline", "progress_pct": 0, "priority": "P1"},
+  {"id": "ci-cd", "name": "CI/CD pipeline", "progress_pct": 100, "priority": "P1"},
   {"id": "tests-core", "name": "Core tests", "progress_pct": 70, "priority": "P0"},
   {"id": "tests-pipeline", "name": "Pipeline/router/session tests", "progress_pct": 0, "priority": "P1"},
   {"id": "tests-cross-encoder", "name": "Cross-encoder HTTP tests", "progress_pct": 0, "priority": "P2"},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  analyze_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run build_runner
+        run: flutter pub run build_runner build
+
+      - name: Run static analysis
+        run: dart analyze lib/
+
+      - name: Run pure-Dart tests
+        run: |
+          flutter test \
+            test/word_piece_tokenizer_test.dart \
+            test/smoke_test.dart \
+            test/sync_manager_test.dart \
+            test/encryption_service_test.dart \
+            test/cross_device_sync_websocket_test.dart


### PR DESCRIPTION
This submission introduces a GitHub Actions CI pipeline to validate on push and pull-request events targeting the `main` branch. The pipeline manages dependency installation, code generation via `build_runner`, static analysis with `dart analyze lib/`, and executes only the pure-Dart tests to avoid failing on native library requirements in generic CI environments. Additionally, the corresponding feature progress has been marked complete in `.gitcore/features.json`.

Fixes #61

---
*PR created automatically by Jules for task [18031419596882541772](https://jules.google.com/task/18031419596882541772) started by @iberi22*