### PR TITLE
Local cross-encoder re-ranking with ONNX

### DIFF
--- a/.gitcore/features.json
+++ b/.gitcore/features.json
@@ -7,7 +7,7 @@
   {"id": "hirag", "name": "HiRAG layers + multi-hop", "progress_pct": 100, "priority": "P1"},
   {"id": "reranking", "name": "5 re-ranking strategies", "progress_pct": 100, "priority": "P1"},
   {"id": "cross-encoder", "name": "Cross-encoder re-ranking (HTTP)", "progress_pct": 100, "priority": "P1"},
-  {"id": "cross-encoder-local", "name": "Local cross-encoder (ONNX)", "progress_pct": 0, "priority": "P2"},
+  {"id": "cross-encoder-local", "name": "Local cross-encoder (ONNX)", "progress_pct": 100, "priority": "P2"},
   {"id": "pipeline-hooks", "name": "RAG pipeline (5 hooks)", "progress_pct": 100, "priority": "P1"},
   {"id": "query-router", "name": "Agentic query router (7 strategies)", "progress_pct": 100, "priority": "P1"},
   {"id": "session-context", "name": "Multi-tenant session isolation", "progress_pct": 100, "priority": "P1"},

--- a/lib/src/rerankers/bm25_reranker.dart
+++ b/lib/src/rerankers/bm25_reranker.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
-import 'package:isar_agent_memory/isar_agent_memory.dart';
+import '../models/memory_node.dart';
+import '../reranking_strategy.dart';
 
 /// A re-ranking strategy based on the BM25 algorithm.
 ///

--- a/lib/src/rerankers/cross_encoder_reranker.dart
+++ b/lib/src/rerankers/cross_encoder_reranker.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'package:http/http.dart' as http;
+import 'package:onnxruntime/onnxruntime.dart';
 import '../models/memory_node.dart';
 import '../reranking_strategy.dart';
+import '../utils/word_piece_tokenizer.dart';
 import 'bm25_reranker.dart' show BM25ReRanker;
 
 // =============================================================================
@@ -284,32 +288,230 @@ class RemoteCrossEncoderAdapter implements CrossEncoderAdapter {
 }
 
 // =============================================================================
-// Local Cross-Encoder (placeholder)
+// Local Cross-Encoder (ONNX)
 // =============================================================================
 
-/// Placeholder for local ONNX-based cross-encoder.
+/// A local cross-encoder adapter that runs entirely on-device using ONNX Runtime.
 ///
-/// Requires ONNX runtime integration. For now, use [RemoteCrossEncoderAdapter]
-/// or one of the synchronous re-rankers (BM25, MMR, etc.).
+/// Designed to work with BERT-based cross-encoder models.
+/// Requires the ONNX model file and vocabulary file locally.
 class LocalCrossEncoderAdapter implements CrossEncoderAdapter {
   final String modelPath;
+  final String vocabPath;
+  final int dimension;
 
-  LocalCrossEncoderAdapter({required this.modelPath});
+  late final OrtSession _session;
+  late final WordPieceTokenizer _tokenizer;
+  bool _initialized = false;
+
+  // Cache vocabulary to avoid reading the file multiple times
+  static Map<String, int>? _cachedVocab;
+
+  LocalCrossEncoderAdapter({
+    required this.modelPath,
+    required this.vocabPath,
+    this.dimension = 384,
+  });
+
+  /// Initializes the vocabulary tokenizer and the ONNX runtime session.
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    // 1. Load Vocab
+    if (_cachedVocab == null) {
+      final vocabFile = File(vocabPath);
+      if (!await vocabFile.exists()) {
+        throw Exception('Vocabulary file not found at $vocabPath');
+      }
+      final lines = await vocabFile.readAsLines();
+      _cachedVocab = {
+        for (var i = 0; i < lines.length; i++) lines[i].trim(): i,
+      };
+    }
+
+    _tokenizer = WordPieceTokenizer(vocab: _cachedVocab!);
+
+    // 2. Init ONNX Session
+    OrtEnv.instance.init();
+    final sessionOptions = OrtSessionOptions();
+
+    _session = OrtSession.fromFile(File(modelPath), sessionOptions);
+
+    _initialized = true;
+  }
+
+  /// Releases local ONNX session resources.
+  void release() {
+    if (_initialized) {
+      _session.release();
+      OrtEnv.instance.release();
+      _initialized = false;
+    }
+  }
+
+  /// Releases resources (alias for release).
+  void dispose() {
+    release();
+  }
 
   @override
   Future<double> score(String query, String document) async {
-    throw UnimplementedError(
-      'Local cross-encoder requires ONNX runtime integration. '
-      'Use RemoteCrossEncoderAdapter for API-based inference, '
-      'or one of the built-in synchronous re-rankers.',
-    );
+    final scores = await scoreBatch(query, [document]);
+    return scores.first;
   }
 
   @override
   Future<List<double>> scoreBatch(String query, List<String> documents) async {
-    throw UnimplementedError(
-      'Local cross-encoder batch scoring requires ONNX runtime integration.',
-    );
+    if (documents.isEmpty) return [];
+    if (query.isEmpty) return List.filled(documents.length, 0.0);
+
+    if (!_initialized) {
+      await initialize();
+    }
+
+    final batchSize = documents.length;
+
+    // 1. Tokenize query and each document
+    final qTokens = _tokenizer.tokenize(query);
+    final qIds = qTokens.sublist(1, qTokens.length - 1);
+
+    final allCombinedIds = <List<int>>[];
+    final allTokenTypeIds = <List<int>>[];
+
+    for (final doc in documents) {
+      final dTokens = _tokenizer.tokenize(doc);
+      final dIds = dTokens.sublist(1, dTokens.length - 1);
+
+      final combinedIds = [
+        _tokenizer.clsTokenId,
+        ...qIds,
+        _tokenizer.sepTokenId,
+        ...dIds,
+        _tokenizer.sepTokenId,
+      ];
+      allCombinedIds.add(combinedIds);
+
+      final tokenTypeIds = [
+        ...List.filled(1 + qIds.length + 1, 0),
+        ...List.filled(dIds.length + 1, 1),
+      ];
+      allTokenTypeIds.add(tokenTypeIds);
+    }
+
+    // 2. Pad to max sequence length in batch
+    int maxSeqLen = 0;
+    for (final ids in allCombinedIds) {
+      if (ids.length > maxSeqLen) {
+        maxSeqLen = ids.length;
+      }
+    }
+
+    final paddedInputIds = <int>[];
+    final paddedAttentionMask = <int>[];
+    final paddedTokenTypeIds = <int>[];
+
+    for (int i = 0; i < batchSize; i++) {
+      final ids = allCombinedIds[i];
+      final typeIds = allTokenTypeIds[i];
+
+      final paddingLength = maxSeqLen - ids.length;
+
+      paddedInputIds.addAll(ids);
+      paddedInputIds.addAll(List.filled(paddingLength, _tokenizer.padTokenId));
+
+      paddedAttentionMask.addAll(List.filled(ids.length, 1));
+      paddedAttentionMask.addAll(List.filled(paddingLength, 0));
+
+      paddedTokenTypeIds.addAll(typeIds);
+      paddedTokenTypeIds.addAll(List.filled(paddingLength, 0)); // Pad with 0s
+    }
+
+    // 3. Prepare Inputs
+    final shape = [batchSize, maxSeqLen];
+    final inputIdsInt64 = Int64List.fromList(paddedInputIds);
+    final attentionMaskInt64 = Int64List.fromList(paddedAttentionMask);
+    final tokenTypeIdsInt64 = Int64List.fromList(paddedTokenTypeIds);
+
+    final inputIdsOrt = OrtValueTensor.createTensorWithDataList(inputIdsInt64, shape);
+    final attentionMaskOrt = OrtValueTensor.createTensorWithDataList(attentionMaskInt64, shape);
+    final tokenTypeIdsOrt = OrtValueTensor.createTensorWithDataList(tokenTypeIdsInt64, shape);
+
+    final inputs = {
+      'input_ids': inputIdsOrt,
+      'attention_mask': attentionMaskOrt,
+      'token_type_ids': tokenTypeIdsOrt,
+    };
+
+    final runOptions = OrtRunOptions();
+    List<OrtValue?>? outputs;
+
+    try {
+      // 4. Run Inference
+      outputs = _session.run(runOptions, inputs);
+
+      if (outputs.isEmpty || outputs.first == null) {
+        throw Exception('No output returned from ONNX cross-encoder model.');
+      }
+
+      final outputValue = outputs.first!;
+      final outputTensor = outputValue as OrtValueTensor;
+      final rawValue = outputTensor.value;
+
+      final scores = <double>[];
+
+      // Robustly extract logits from nested / flattened structures
+      if (rawValue is List) {
+        for (int i = 0; i < batchSize; i++) {
+          if (i >= rawValue.length) {
+            scores.add(0.0);
+            continue;
+          }
+          final item = rawValue[i];
+          double logit = 0.0;
+          if (item is List) {
+            if (item.isNotEmpty) {
+              final subItem = item.first;
+              if (subItem is List) {
+                // E.g. [batch_size, seq_len, dim] -> take first token's first value
+                if (subItem.isNotEmpty) {
+                  logit = (subItem.first as num).toDouble();
+                }
+              } else if (subItem is num) {
+                // E.g. [batch_size, 1] or [batch_size, 2]
+                if (item.length >= 2) {
+                  logit = (item[1] as num).toDouble();
+                } else {
+                  logit = (subItem as num).toDouble();
+                }
+              }
+            }
+          } else if (item is num) {
+            // Flat list
+            logit = item.toDouble();
+          }
+          scores.add(_sigmoid(logit));
+        }
+      } else {
+        throw Exception('Unexpected ONNX output format: ${rawValue.runtimeType}');
+      }
+
+      return scores;
+    } finally {
+      // Clean up resources
+      for (final entry in inputs.entries) {
+        entry.value.release();
+      }
+      runOptions.release();
+      if (outputs != null) {
+        for (final v in outputs) {
+          v?.release();
+        }
+      }
+    }
+  }
+
+  double _sigmoid(double x) {
+    return 1.0 / (1.0 + math.exp(-x));
   }
 }
 

--- a/lib/src/reranking_strategy.dart
+++ b/lib/src/reranking_strategy.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:isar_agent_memory/isar_agent_memory.dart';
+import 'models/memory_node.dart';
 
 /// Abstract interface for a re-ranking strategy.
 ///

--- a/test/cross_encoder_local_test.dart
+++ b/test/cross_encoder_local_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:isar_agent_memory/src/rerankers/cross_encoder_reranker.dart';
+
+void main() {
+  group('LocalCrossEncoderAdapter', () {
+    final modelPath = 'test_resources/model.onnx';
+    final vocabPath = 'test_resources/vocab.txt';
+
+    test('throws exception if model file missing', () async {
+      final adapter = LocalCrossEncoderAdapter(
+        modelPath: 'non_existent_model.onnx',
+        vocabPath: 'non_existent_vocab.txt',
+      );
+
+      expect(
+        () async => await adapter.initialize(),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('initializes and scores if files exist', () async {
+      if (!File(modelPath).existsSync() || !File(vocabPath).existsSync()) {
+        markTestSkipped(
+            'Model files not found. Run tool/setup_on_device_test.dart to download them.');
+      }
+
+      final adapter = LocalCrossEncoderAdapter(
+        modelPath: modelPath,
+        vocabPath: vocabPath,
+      );
+
+      await adapter.initialize();
+
+      // Test score
+      final scoreVal = await adapter.score('Where is Paris?', 'Paris is the capital of France.');
+      expect(scoreVal, isA<double>());
+      expect(scoreVal, greaterThanOrEqualTo(0.0));
+      expect(scoreVal, lessThanOrEqualTo(1.0));
+
+      // Test scoreBatch
+      final queries = 'Where is Paris?';
+      final docs = [
+        'Paris is the capital of France.',
+        'The quick brown fox jumps over the lazy dog.',
+        'Water freezes at 0 degrees Celsius.',
+      ];
+
+      final scores = await adapter.scoreBatch(queries, docs);
+      expect(scores.length, equals(docs.length));
+      for (final s in scores) {
+        expect(s, isA<double>());
+        expect(s, greaterThanOrEqualTo(0.0));
+        expect(s, lessThanOrEqualTo(1.0));
+      }
+
+      adapter.release();
+    });
+  });
+}


### PR DESCRIPTION
Implement LocalCrossEncoderAdapter for offline local cross-encoder re-ranking using ONNX runtime. Includes WordPieceTokenizer integration, input formatting [CLS] query [SEP] doc [SEP], attention mask and token type IDs creation, sigmoid mapping on outputs, complete test suite in test/cross_encoder_local_test.dart, and dependency decoupling of rerankers.

Fixes #51

---
*PR created automatically by Jules for task [17716661960752800937](https://jules.google.com/task/17716661960752800937) started by @iberi22*