### PR TITLE
Complete Agent Memory Demo and Generate Isar Schemas

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,46 +1,278 @@
+import 'dart:io';
 import 'package:isar/isar.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
-import 'dart:io';
 
 Future<void> main() async {
-  // Set your Gemini API key here or via environment variable
-  final apiKey =
-      Platform.environment['GEMINI_API_KEY'] ?? '<YOUR_GEMINI_API_KEY>';
-  final adapter = GeminiEmbeddingsAdapter(apiKey: apiKey);
+  print('====================================================');
+  print('          AGENT MEMORY SDK DEMONSTRATION            ');
+  print('====================================================\n');
 
-  // Initialize Isar Core for pure Dart
+  // Initialize Isar Core for pure Dart environment
   await Isar.initializeIsarCore(download: true);
 
-  // Create the directory for the Isar database
-  await Directory('./exampledb').create(recursive: true);
+  // 1. Setup deterministic Hash Embedding Backend
+  // A local-first hash-based embedding adapter guarantees we can run this
+  // demo offline/without API keys, while still producing reproducible vector search.
+  final backend = HashEmbeddingBackend(dimension: 256);
+  final adapter = BackendEmbeddingsAdapter(backend: backend);
+  await adapter.ensureLoaded();
 
-  // Open Isar in a temp directory for demo
+  // Create clean temporary directory for Isar database
+  final dbDir = Directory('./exampledb');
+  if (await dbDir.exists()) {
+    try {
+      await dbDir.delete(recursive: true);
+    } catch (_) {
+      // Ignored if directory cannot be deleted immediately
+    }
+  }
+  await dbDir.create(recursive: true);
+
+  // Open Isar Database with schemas from the package
   final isar = await Isar.open(
     [MemoryNodeSchema, MemoryEdgeSchema],
-    inspector: false,
-    directory: './exampledb',
+    directory: dbDir.path,
   );
+
+  // Create our universal Memory Graph
   final graph = MemoryGraph(isar, embeddingsAdapter: adapter);
 
-  // Store a node with embedding
-  final nodeId = await graph.storeNodeWithEmbedding(
-      content: 'The quick brown fox jumps over the lazy dog.');
-  print('Stored node with id: $nodeId');
+  try {
+    // -------------------------------------------------------------------
+    // Step 2: GRAPH CRUD OPERATIONS
+    // -------------------------------------------------------------------
+    print('--- [1/5] GRAPH CRUD OPERATIONS ---');
 
-  // Query with a similar phrase
-  final queryEmbedding = await adapter.embed('A fox jumps over a dog');
-  final results = await graph.semanticSearch(queryEmbedding, topK: 3);
-  for (final result in results) {
-    print(
-        'Node: ${result.node.content}, Distance: ${result.distance.toStringAsFixed(3)}, Provider: ${result.provider}');
+    // CREATE: Store nodes representing concepts or facts with auto-generated embeddings
+    final node1Id = await graph.storeNodeWithEmbedding(
+      content: 'Seattle is a beautiful city in Washington state known for rain.',
+      type: 'location_fact',
+    );
+    final node2Id = await graph.storeNodeWithEmbedding(
+      content: 'The Space Needle is an iconic observation tower located in Seattle.',
+      type: 'landmark_fact',
+    );
+    print('Created Node 1 (Seattle) with ID: $node1Id');
+    print('Created Node 2 (Space Needle) with ID: $node2Id');
+
+    // CREATE EDGE: Connect the nodes via a directed relationship edge
+    final edgeId = await graph.storeEdge(MemoryEdge(
+      fromNodeId: node2Id,
+      toNodeId: node1Id,
+      relation: 'is_located_in',
+      weight: 0.95,
+    ));
+    print('Created Edge connecting Node 2 -> Node 1 (ID: $edgeId)\n');
+
+    // READ: Retrieve nodes from the graph
+    final fetchedNode1 = await graph.getNode(node1Id);
+    if (fetchedNode1 != null) {
+      print('Retrieved Node 1 content: "${fetchedNode1.content}"');
+    }
+
+    // UPDATE: Modify the node content (e.g., add new details)
+    if (fetchedNode1 != null) {
+      fetchedNode1.content = 'Seattle is a beautiful city in Washington (WA) known for rain and tech companies.';
+      await graph.storeNode(fetchedNode1);
+      print('Updated Node 1 content.');
+    }
+
+    // SEMANTIC SEARCH: Search the graph using semantic similarity
+    print('\nPerforming Semantic Search for "Space Needle tower"...');
+    final queryVector = await adapter.embed('Space Needle tower');
+    final searchResults = await graph.semanticSearch(queryVector, topK: 2);
+    for (final result in searchResults) {
+      print(' - Node ID: ${result.node.id}, Content: "${result.node.content}"');
+      print('   Similarity Distance: ${result.distance.toStringAsFixed(4)} (Provider: ${result.provider})');
+    }
+
+    // EXPLAIN RECALL: Get graph path explanation
+    if (searchResults.isNotEmpty) {
+      print('\nExplaining recall path for the top match:');
+      final explanation = await graph.explainRecall(
+        searchResults.first.node.id,
+        queryEmbedding: queryVector,
+      );
+      print(' Explanation:\n $explanation\n');
+    }
+
+    // -------------------------------------------------------------------
+    // Step 3: SESSION ISOLATION & CONTEXT
+    // -------------------------------------------------------------------
+    print('--- [2/5] SESSION & TENANT ISOLATION ---');
+
+    // Create isolated contexts for different users using SessionContext
+    final aliceSession = SessionContext(graph: graph, sessionId: 'alice-session-456');
+    final bobSession = SessionContext(graph: graph, sessionId: 'bob-session-789');
+
+    // Store private information scoped to each user
+    await aliceSession.store('Alice prefers drinking hot Earl Grey tea in the morning.', type: 'preference');
+    await bobSession.store('Bob prefers drinking black iced coffee in the morning.', type: 'preference');
+
+    print('Stored session-scoped preference for Alice.');
+    print('Stored session-scoped preference for Bob.');
+
+    // Search inside Alice\'s session
+    print('\nSearching for "morning beverage preference" in Alice\'s session:');
+    final aliceQueryVector = await adapter.embed('morning beverage preference');
+    final aliceResults = await aliceSession.semanticSearch(aliceQueryVector, topK: 3);
+    for (final r in aliceResults) {
+      print(' - [Alice Session] Found: "${r.node.content}" (Distance: ${r.distance.toStringAsFixed(4)})');
+    }
+
+    // Search inside Bob\'s session
+    print('\nSearching for "morning beverage preference" in Bob\'s session:');
+    final bobQueryVector = await adapter.embed('morning beverage preference');
+    final bobResults = await bobSession.semanticSearch(bobQueryVector, topK: 3);
+    for (final r in bobResults) {
+      print(' - [Bob Session] Found: "${r.node.content}" (Distance: ${r.distance.toStringAsFixed(4)})');
+    }
+    print('');
+
+    // -------------------------------------------------------------------
+    // Step 4: QUERY ROUTER (HEURISTIC RETRIEVAL)
+    // -------------------------------------------------------------------
+    print('--- [3/5] AGENTIC QUERY ROUTER ---');
+
+    final router = QueryRouter(graph: graph, embeddings: adapter);
+
+    // Formulate queries with different intents: temporal, graph/relationship, precise terms, vector
+    final queries = [
+      'What did Alice do yesterday?', // Temporal intent
+      'How is the Space Needle related to Seattle?', // Graph/relationship intent
+      'Specific protocol WA standard format v1', // Precise term / hybrid intent
+      'Beautiful rainy cities', // Standard vector intent
+    ];
+
+    for (final query in queries) {
+      // 1. Classify the query intent and confidence
+      final plan = router.classify(query);
+      print('Query: "$query"');
+      print(' -> Strategy:  ${plan.strategy.name.toUpperCase()}');
+      print(' -> Confidence: ${(plan.confidence * 100).toStringAsFixed(0)}%');
+      print(' -> Reasoning:  ${plan.reasoning}');
+
+      // 2. Execute the routed strategy
+      final results = await router.execute(plan);
+      print(' -> Results count: ${results.length}');
+      if (results.isNotEmpty) {
+        print(' -> Top Result: "${results.first.node.content}" (Source: ${results.first.source})');
+      }
+      print('----------------------------------------------------');
+    }
+    print('');
+
+    // -------------------------------------------------------------------
+    // Step 5: COMPOSABLE RAG PIPELINE
+    // -------------------------------------------------------------------
+    print('--- [4/5] COMPOSABLE RAG PIPELINE ---');
+
+    // Set up a custom composable RAG pipeline
+    final pipeline = MemoryPipeline();
+
+    // Add a custom Query Expansion hook (e.g. expands acronym "WA" to "Washington State")
+    pipeline.addExpansionHook(_CustomQueryExpansionHook());
+
+    // Add retrieval stage: use the built-in vector search retrieval hook
+    pipeline.addRetrievalHook(VectorRetrievalHook(
+      graph: graph,
+      embeddings: adapter,
+      topK: 3,
+    ));
+
+    // Add enrichment stage: use HiRAG multi-hop explanation hook to append graph path context
+    pipeline.addEnrichmentHook(MultiHopEnrichmentHook(
+      graph: graph,
+      maxHops: 2,
+    ));
+
+    // Run the pipeline for a query containing the WA abbreviation
+    final pipelineQuery = 'What is there to do in WA?';
+    print('Running custom pipeline for: "$pipelineQuery"');
+
+    final pipelineResult = await pipeline.run(pipelineQuery);
+    print('Pipeline elapsed time: ${pipelineResult.elapsed.inMilliseconds}ms');
+    print('Expanded Queries: ${pipelineResult.context.expandedQueries}');
+    print('Pipeline Results:');
+    for (final result in pipelineResult.results) {
+      print(' - Node ID: ${result.node.id}, Content: "${result.node.content}"');
+      print('   Score: ${result.score.toStringAsFixed(4)}, Source: ${result.source}');
+      print('   Enrichment Explanation: ${result.explanation}');
+    }
+    print('');
+
+    // -------------------------------------------------------------------
+    // Step 6: RESULT RE-RANKING STRATEGIES
+    // -------------------------------------------------------------------
+    print('--- [5/5] RESULT RE-RANKING ---');
+
+    // Create a pool of nodes of varying relevance for re-ranking
+    final searchOutput = <({MemoryNode node, double score})>[];
+
+    final nodesToRank = [
+      'Seattle rain is very constant during the winter months.',
+      'Washington state has many hiking trails near Mount Rainier.',
+      'Drinking Earl Grey tea is highly recommended in Seattle.',
+      'Space Needle is tall.',
+    ];
+
+    for (var i = 0; i < nodesToRank.length; i++) {
+      final node = MemoryNode(content: nodesToRank[i]);
+      // Assign deterministic embeddings for diversity comparison
+      node.embedding = MemoryEmbedding(vector: await adapter.embed(nodesToRank[i]));
+      searchOutput.add((node: node, score: 0.9 - (i * 0.1)));
+    }
+
+    print('Original Search Result Order (highest score first):');
+    for (final r in searchOutput) {
+      print(' - [Score: ${r.score.toStringAsFixed(2)}] "${r.node.content}"');
+    }
+
+    // 1. BM25 Re-ranker (lexical keyword matching)
+    print('\nApplying BM25 Re-ranking for query "rain Seattle":');
+    final bm25Ranker = BM25ReRanker();
+    final bm25Results = await bm25Ranker.reRank(searchOutput, query: 'rain Seattle');
+    for (final r in bm25Results) {
+      print(' - "${r.node.content}"');
+    }
+
+    // 2. Diversity Re-ranker (uses Cosine Similarity on embeddings to avoid redundant topics)
+    print('\nApplying Diversity Re-ranking to maximize informational novelty:');
+    final diversityRanker = DiversityReRanker();
+    final diverseResults = await diversityRanker.reRank(searchOutput);
+    for (final r in diverseResults) {
+      print(' - "${r.node.content}"');
+    }
+
+    // Clean up nodes
+    print('\nCleaning up and closing database...');
+    // DELETE: Demonstrate deleting nodes
+    final deletedCount = await graph.deleteNode(node1Id);
+    print('Deleted Node 1 (Seattle). Affected nodes/edges count: $deletedCount');
+
+  } finally {
+    // Make sure we release native backend resources and close Isar cleanly
+    await adapter.dispose();
+    await isar.close();
+    print('\nDatabase closed successfully. Demo complete!');
+    print('====================================================');
   }
+}
 
-  // Explain recall for the top result
-  if (results.isNotEmpty) {
-    final explanation = await graph.explainRecall(results.first.node.id,
-        queryEmbedding: queryEmbedding);
-    print('Explain: $explanation');
+/// Custom Query Expansion Hook implementation.
+/// Rewrites queries containing "WA" to "Washington State" to improve retrieval recall.
+class _CustomQueryExpansionHook implements QueryExpansionHook {
+  @override
+  int get priority => 10; // lower priority runs first
+
+  @override
+  Future<void> expand(PipelineContext context) async {
+    final query = context.query;
+    if (query.contains('WA')) {
+      final expanded = query.replaceAll('WA', 'Washington State');
+      context.expandedQueries = [expanded];
+    } else {
+      context.expandedQueries = [query];
+    }
   }
-
-  await isar.close(deleteFromDisk: true);
 }

--- a/lib/src/models/degree.g.dart
+++ b/lib/src/models/degree.g.dart
@@ -3,6 +3,279 @@
 part of 'degree.dart';
 
 // **************************************************************************
+// IsarEmbeddedGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+const DegreeSchema = Schema(
+  name: r'Degree',
+  id: 8962167479248401892,
+  properties: {
+    r'frequency': PropertySchema(
+      id: 0,
+      name: r'frequency',
+      type: IsarType.long,
+    ),
+    r'importance': PropertySchema(
+      id: 1,
+      name: r'importance',
+      type: IsarType.double,
+    ),
+    r'lastAccessed': PropertySchema(
+      id: 2,
+      name: r'lastAccessed',
+      type: IsarType.dateTime,
+    )
+  },
+  estimateSize: _degreeEstimateSize,
+  serialize: _degreeSerialize,
+  deserialize: _degreeDeserialize,
+  deserializeProp: _degreeDeserializeProp,
+);
+
+int _degreeEstimateSize(
+  Degree object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  return bytesCount;
+}
+
+void _degreeSerialize(
+  Degree object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeLong(offsets[0], object.frequency);
+  writer.writeDouble(offsets[1], object.importance);
+  writer.writeDateTime(offsets[2], object.lastAccessed);
+}
+
+Degree _degreeDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = Degree(
+    frequency: reader.readLongOrNull(offsets[0]) ?? 0,
+    importance: reader.readDoubleOrNull(offsets[1]) ?? 0.5,
+    lastAccessed: reader.readDateTimeOrNull(offsets[2]),
+  );
+  return object;
+}
+
+P _degreeDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 1:
+      return (reader.readDoubleOrNull(offset) ?? 0.5) as P;
+    case 2:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension DegreeQueryFilter on QueryBuilder<Degree, Degree, QFilterCondition> {
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> frequencyEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'frequency',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> frequencyGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'frequency',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> frequencyLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'frequency',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> frequencyBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'frequency',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> importanceEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'importance',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> importanceGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'importance',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> importanceLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'importance',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> importanceBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'importance',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'lastAccessed',
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'lastAccessed',
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastAccessed',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lastAccessed',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lastAccessed',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Degree, Degree, QAfterFilterCondition> lastAccessedBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lastAccessed',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension DegreeQueryObject on QueryBuilder<Degree, Degree, QFilterCondition> {}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
@@ -10,7 +283,7 @@ Degree _$DegreeFromJson(Map<String, dynamic> json) => Degree(
       lastAccessed: json['lastAccessed'] == null
           ? null
           : DateTime.parse(json['lastAccessed'] as String),
-      frequency: (json['frequency'] as num?)?.toInt() ?? 0,
+      frequency: json['frequency'] as int? ?? 0,
       importance: (json['importance'] as num?)?.toDouble() ?? 0.5,
     );
 

--- a/lib/src/models/memory_edge.dart
+++ b/lib/src/models/memory_edge.dart
@@ -38,7 +38,7 @@ class MemoryEdge {
   /// Globally unique identifier for synchronization.
   /// Indexed for fast lookups during sync.
   @Index(unique: true, replace: true)
-  late String uuid;
+  String? uuid;
 
   /// The ID of the source node (the origin of the relationship).
   late int fromNodeId;

--- a/lib/src/models/memory_edge.g.dart
+++ b/lib/src/models/memory_edge.g.dart
@@ -3,12 +3,1775 @@
 part of 'memory_edge.dart';
 
 // **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetMemoryEdgeCollection on Isar {
+  IsarCollection<MemoryEdge> get memoryEdges => this.collection();
+}
+
+const MemoryEdgeSchema = CollectionSchema(
+  name: r'MemoryEdge',
+  id: 2749767584170770699,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'deviceId': PropertySchema(
+      id: 1,
+      name: r'deviceId',
+      type: IsarType.string,
+    ),
+    r'fromNodeId': PropertySchema(
+      id: 2,
+      name: r'fromNodeId',
+      type: IsarType.long,
+    ),
+    r'isDeleted': PropertySchema(
+      id: 3,
+      name: r'isDeleted',
+      type: IsarType.bool,
+    ),
+    r'modifiedAt': PropertySchema(
+      id: 4,
+      name: r'modifiedAt',
+      type: IsarType.dateTime,
+    ),
+    r'relation': PropertySchema(
+      id: 5,
+      name: r'relation',
+      type: IsarType.string,
+    ),
+    r'toNodeId': PropertySchema(
+      id: 6,
+      name: r'toNodeId',
+      type: IsarType.long,
+    ),
+    r'uuid': PropertySchema(
+      id: 7,
+      name: r'uuid',
+      type: IsarType.string,
+    ),
+    r'version': PropertySchema(
+      id: 8,
+      name: r'version',
+      type: IsarType.string,
+    ),
+    r'weight': PropertySchema(
+      id: 9,
+      name: r'weight',
+      type: IsarType.double,
+    )
+  },
+  estimateSize: _memoryEdgeEstimateSize,
+  serialize: _memoryEdgeSerialize,
+  deserialize: _memoryEdgeDeserialize,
+  deserializeProp: _memoryEdgeDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'uuid': IndexSchema(
+      id: 2134397340427724972,
+      name: r'uuid',
+      unique: true,
+      replace: true,
+      properties: [
+        IndexPropertySchema(
+          name: r'uuid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _memoryEdgeGetId,
+  getLinks: _memoryEdgeGetLinks,
+  attach: _memoryEdgeAttach,
+  version: '3.1.0+1',
+);
+
+int _memoryEdgeEstimateSize(
+  MemoryEdge object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.deviceId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.relation.length * 3;
+  {
+    final value = object.uuid;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.version;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _memoryEdgeSerialize(
+  MemoryEdge object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeString(offsets[1], object.deviceId);
+  writer.writeLong(offsets[2], object.fromNodeId);
+  writer.writeBool(offsets[3], object.isDeleted);
+  writer.writeDateTime(offsets[4], object.modifiedAt);
+  writer.writeString(offsets[5], object.relation);
+  writer.writeLong(offsets[6], object.toNodeId);
+  writer.writeString(offsets[7], object.uuid);
+  writer.writeString(offsets[8], object.version);
+  writer.writeDouble(offsets[9], object.weight);
+}
+
+MemoryEdge _memoryEdgeDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = MemoryEdge(
+    deviceId: reader.readStringOrNull(offsets[1]),
+    fromNodeId: reader.readLong(offsets[2]),
+    isDeleted: reader.readBoolOrNull(offsets[3]) ?? false,
+    modifiedAt: reader.readDateTimeOrNull(offsets[4]),
+    relation: reader.readString(offsets[5]),
+    toNodeId: reader.readLong(offsets[6]),
+    uuid: reader.readStringOrNull(offsets[7]),
+    version: reader.readStringOrNull(offsets[8]),
+    weight: reader.readDoubleOrNull(offsets[9]),
+  );
+  object.createdAt = reader.readDateTime(offsets[0]);
+  object.id = id;
+  return object;
+}
+
+P _memoryEdgeDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    case 2:
+      return (reader.readLong(offset)) as P;
+    case 3:
+      return (reader.readBoolOrNull(offset) ?? false) as P;
+    case 4:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 5:
+      return (reader.readString(offset)) as P;
+    case 6:
+      return (reader.readLong(offset)) as P;
+    case 7:
+      return (reader.readStringOrNull(offset)) as P;
+    case 8:
+      return (reader.readStringOrNull(offset)) as P;
+    case 9:
+      return (reader.readDoubleOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _memoryEdgeGetId(MemoryEdge object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _memoryEdgeGetLinks(MemoryEdge object) {
+  return [];
+}
+
+void _memoryEdgeAttach(IsarCollection<dynamic> col, Id id, MemoryEdge object) {
+  object.id = id;
+}
+
+extension MemoryEdgeByIndex on IsarCollection<MemoryEdge> {
+  Future<MemoryEdge?> getByUuid(String? uuid) {
+    return getByIndex(r'uuid', [uuid]);
+  }
+
+  MemoryEdge? getByUuidSync(String? uuid) {
+    return getByIndexSync(r'uuid', [uuid]);
+  }
+
+  Future<bool> deleteByUuid(String? uuid) {
+    return deleteByIndex(r'uuid', [uuid]);
+  }
+
+  bool deleteByUuidSync(String? uuid) {
+    return deleteByIndexSync(r'uuid', [uuid]);
+  }
+
+  Future<List<MemoryEdge?>> getAllByUuid(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return getAllByIndex(r'uuid', values);
+  }
+
+  List<MemoryEdge?> getAllByUuidSync(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'uuid', values);
+  }
+
+  Future<int> deleteAllByUuid(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'uuid', values);
+  }
+
+  int deleteAllByUuidSync(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'uuid', values);
+  }
+
+  Future<Id> putByUuid(MemoryEdge object) {
+    return putByIndex(r'uuid', object);
+  }
+
+  Id putByUuidSync(MemoryEdge object, {bool saveLinks = true}) {
+    return putByIndexSync(r'uuid', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByUuid(List<MemoryEdge> objects) {
+    return putAllByIndex(r'uuid', objects);
+  }
+
+  List<Id> putAllByUuidSync(List<MemoryEdge> objects, {bool saveLinks = true}) {
+    return putAllByIndexSync(r'uuid', objects, saveLinks: saveLinks);
+  }
+}
+
+extension MemoryEdgeQueryWhereSort
+    on QueryBuilder<MemoryEdge, MemoryEdge, QWhere> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension MemoryEdgeQueryWhere
+    on QueryBuilder<MemoryEdge, MemoryEdge, QWhereClause> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> uuidIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uuid',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> uuidIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'uuid',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> uuidEqualTo(
+      String? uuid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uuid',
+        value: [uuid],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterWhereClause> uuidNotEqualTo(
+      String? uuid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [],
+              upper: [uuid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [uuid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [uuid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [],
+              upper: [uuid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension MemoryEdgeQueryFilter
+    on QueryBuilder<MemoryEdge, MemoryEdge, QFilterCondition> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> createdAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'deviceId',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      deviceIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'deviceId',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      deviceIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'deviceId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      deviceIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> deviceIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'deviceId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      deviceIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'deviceId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      deviceIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'deviceId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> fromNodeIdEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'fromNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      fromNodeIdGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'fromNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      fromNodeIdLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'fromNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> fromNodeIdBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'fromNodeId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> isDeletedEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isDeleted',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      modifiedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'modifiedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      modifiedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'modifiedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> modifiedAtEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      modifiedAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      modifiedAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> modifiedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'modifiedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      relationGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'relation',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      relationStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'relation',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> relationMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'relation',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      relationIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'relation',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      relationIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'relation',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> toNodeIdEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'toNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      toNodeIdGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'toNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> toNodeIdLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'toNodeId',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> toNodeIdBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'toNodeId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'uuid',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'uuid',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'uuid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'uuid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uuid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> uuidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'uuid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'version',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      versionIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'version',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      versionGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'version',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'version',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> versionIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'version',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      versionIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'version',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> weightIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'weight',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition>
+      weightIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'weight',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> weightEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> weightGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> weightLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'weight',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterFilterCondition> weightBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'weight',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+}
+
+extension MemoryEdgeQueryObject
+    on QueryBuilder<MemoryEdge, MemoryEdge, QFilterCondition> {}
+
+extension MemoryEdgeQueryLinks
+    on QueryBuilder<MemoryEdge, MemoryEdge, QFilterCondition> {}
+
+extension MemoryEdgeQuerySortBy
+    on QueryBuilder<MemoryEdge, MemoryEdge, QSortBy> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByFromNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fromNodeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByFromNodeIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fromNodeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByIsDeletedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByRelation() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'relation', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByRelationDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'relation', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByToNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'toNodeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByToNodeIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'toNodeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByUuid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByUuidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByVersion() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByVersionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByWeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'weight', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> sortByWeightDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'weight', Sort.desc);
+    });
+  }
+}
+
+extension MemoryEdgeQuerySortThenBy
+    on QueryBuilder<MemoryEdge, MemoryEdge, QSortThenBy> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByFromNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fromNodeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByFromNodeIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'fromNodeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByIsDeletedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByRelation() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'relation', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByRelationDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'relation', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByToNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'toNodeId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByToNodeIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'toNodeId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByUuid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByUuidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByVersion() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByVersionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByWeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'weight', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QAfterSortBy> thenByWeightDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'weight', Sort.desc);
+    });
+  }
+}
+
+extension MemoryEdgeQueryWhereDistinct
+    on QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> {
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByDeviceId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'deviceId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByFromNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'fromNodeId');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isDeleted');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByRelation(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'relation', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByToNodeId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'toNodeId');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByUuid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'uuid', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByVersion(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'version', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryEdge, MemoryEdge, QDistinct> distinctByWeight() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'weight');
+    });
+  }
+}
+
+extension MemoryEdgeQueryProperty
+    on QueryBuilder<MemoryEdge, MemoryEdge, QQueryProperty> {
+  QueryBuilder<MemoryEdge, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, String?, QQueryOperations> deviceIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'deviceId');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, int, QQueryOperations> fromNodeIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'fromNodeId');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, bool, QQueryOperations> isDeletedProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isDeleted');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, DateTime?, QQueryOperations> modifiedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, String, QQueryOperations> relationProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'relation');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, int, QQueryOperations> toNodeIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'toNodeId');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, String?, QQueryOperations> uuidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'uuid');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, String?, QQueryOperations> versionProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'version');
+    });
+  }
+
+  QueryBuilder<MemoryEdge, double?, QQueryOperations> weightProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'weight');
+    });
+  }
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
 MemoryEdge _$MemoryEdgeFromJson(Map<String, dynamic> json) => MemoryEdge(
-      fromNodeId: (json['fromNodeId'] as num).toInt(),
-      toNodeId: (json['toNodeId'] as num).toInt(),
+      fromNodeId: json['fromNodeId'] as int,
+      toNodeId: json['toNodeId'] as int,
       relation: json['relation'] as String,
       weight: (json['weight'] as num?)?.toDouble(),
       version: json['version'] as String?,

--- a/lib/src/models/memory_embedding.g.dart
+++ b/lib/src/models/memory_embedding.g.dart
@@ -3,6 +3,446 @@
 part of 'memory_embedding.dart';
 
 // **************************************************************************
+// IsarEmbeddedGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+const MemoryEmbeddingSchema = Schema(
+  name: r'MemoryEmbedding',
+  id: -4127158395713779796,
+  properties: {
+    r'dimension': PropertySchema(
+      id: 0,
+      name: r'dimension',
+      type: IsarType.long,
+    ),
+    r'provider': PropertySchema(
+      id: 1,
+      name: r'provider',
+      type: IsarType.string,
+    ),
+    r'vector': PropertySchema(
+      id: 2,
+      name: r'vector',
+      type: IsarType.doubleList,
+    )
+  },
+  estimateSize: _memoryEmbeddingEstimateSize,
+  serialize: _memoryEmbeddingSerialize,
+  deserialize: _memoryEmbeddingDeserialize,
+  deserializeProp: _memoryEmbeddingDeserializeProp,
+);
+
+int _memoryEmbeddingEstimateSize(
+  MemoryEmbedding object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.provider.length * 3;
+  bytesCount += 3 + object.vector.length * 8;
+  return bytesCount;
+}
+
+void _memoryEmbeddingSerialize(
+  MemoryEmbedding object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeLong(offsets[0], object.dimension);
+  writer.writeString(offsets[1], object.provider);
+  writer.writeDoubleList(offsets[2], object.vector);
+}
+
+MemoryEmbedding _memoryEmbeddingDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = MemoryEmbedding(
+    dimension: reader.readLongOrNull(offsets[0]) ?? 0,
+    provider: reader.readStringOrNull(offsets[1]) ?? 'unknown',
+    vector: reader.readDoubleList(offsets[2]) ?? const [],
+  );
+  return object;
+}
+
+P _memoryEmbeddingDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 1:
+      return (reader.readStringOrNull(offset) ?? 'unknown') as P;
+    case 2:
+      return (reader.readDoubleList(offset) ?? const []) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+extension MemoryEmbeddingQueryFilter
+    on QueryBuilder<MemoryEmbedding, MemoryEmbedding, QFilterCondition> {
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      dimensionEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'dimension',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      dimensionGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'dimension',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      dimensionLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'dimension',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      dimensionBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'dimension',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'provider',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'provider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'provider',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'provider',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      providerIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'provider',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorElementEqualTo(
+    double value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'vector',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorElementGreaterThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'vector',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorElementLessThan(
+    double value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'vector',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorElementBetween(
+    double lower,
+    double upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'vector',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorLengthEqualTo(int length) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        length,
+        true,
+        length,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        0,
+        true,
+        0,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        0,
+        false,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorLengthLessThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        0,
+        true,
+        length,
+        include,
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorLengthGreaterThan(
+    int length, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        length,
+        include,
+        999999,
+        true,
+      );
+    });
+  }
+
+  QueryBuilder<MemoryEmbedding, MemoryEmbedding, QAfterFilterCondition>
+      vectorLengthBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.listLength(
+        r'vector',
+        lower,
+        includeLower,
+        upper,
+        includeUpper,
+      );
+    });
+  }
+}
+
+extension MemoryEmbeddingQueryObject
+    on QueryBuilder<MemoryEmbedding, MemoryEmbedding, QFilterCondition> {}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
@@ -13,7 +453,7 @@ MemoryEmbedding _$MemoryEmbeddingFromJson(Map<String, dynamic> json) =>
               .toList() ??
           const [],
       provider: json['provider'] as String? ?? 'unknown',
-      dimension: (json['dimension'] as num?)?.toInt() ?? 0,
+      dimension: json['dimension'] as int? ?? 0,
     );
 
 Map<String, dynamic> _$MemoryEmbeddingToJson(MemoryEmbedding instance) =>

--- a/lib/src/models/memory_node.dart
+++ b/lib/src/models/memory_node.dart
@@ -47,7 +47,7 @@ class MemoryNode {
   /// Globally unique identifier for synchronization.
   /// Indexed for fast lookups during sync.
   @Index(unique: true, replace: true)
-  late String uuid;
+  String? uuid;
 
   /// The main textual content or value of the memory.
   ///
@@ -62,7 +62,7 @@ class MemoryNode {
   /// The timestamp when this memory node was created.
   ///
   /// Automatically set to the current time upon creation.
-  late DateTime createdAt;
+  DateTime? createdAt;
 
   /// The timestamp of the last update or access (business logic update).
   ///

--- a/lib/src/models/memory_node.g.dart
+++ b/lib/src/models/memory_node.g.dart
@@ -3,6 +3,2102 @@
 part of 'memory_node.dart';
 
 // **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetMemoryNodeCollection on Isar {
+  IsarCollection<MemoryNode> get memoryNodes => this.collection();
+}
+
+const MemoryNodeSchema = CollectionSchema(
+  name: r'MemoryNode',
+  id: 1949420279504451454,
+  properties: {
+    r'accessCount': PropertySchema(
+      id: 0,
+      name: r'accessCount',
+      type: IsarType.long,
+    ),
+    r'content': PropertySchema(
+      id: 1,
+      name: r'content',
+      type: IsarType.string,
+    ),
+    r'createdAt': PropertySchema(
+      id: 2,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'degree': PropertySchema(
+      id: 3,
+      name: r'degree',
+      type: IsarType.object,
+      target: r'Degree',
+    ),
+    r'deviceId': PropertySchema(
+      id: 4,
+      name: r'deviceId',
+      type: IsarType.string,
+    ),
+    r'embedding': PropertySchema(
+      id: 5,
+      name: r'embedding',
+      type: IsarType.object,
+      target: r'MemoryEmbedding',
+    ),
+    r'isDeleted': PropertySchema(
+      id: 6,
+      name: r'isDeleted',
+      type: IsarType.bool,
+    ),
+    r'layer': PropertySchema(
+      id: 7,
+      name: r'layer',
+      type: IsarType.long,
+    ),
+    r'modifiedAt': PropertySchema(
+      id: 8,
+      name: r'modifiedAt',
+      type: IsarType.dateTime,
+    ),
+    r'type': PropertySchema(
+      id: 9,
+      name: r'type',
+      type: IsarType.string,
+    ),
+    r'updatedAt': PropertySchema(
+      id: 10,
+      name: r'updatedAt',
+      type: IsarType.dateTime,
+    ),
+    r'uuid': PropertySchema(
+      id: 11,
+      name: r'uuid',
+      type: IsarType.string,
+    ),
+    r'version': PropertySchema(
+      id: 12,
+      name: r'version',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _memoryNodeEstimateSize,
+  serialize: _memoryNodeSerialize,
+  deserialize: _memoryNodeDeserialize,
+  deserializeProp: _memoryNodeDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'uuid': IndexSchema(
+      id: 2134397340427724972,
+      name: r'uuid',
+      unique: true,
+      replace: true,
+      properties: [
+        IndexPropertySchema(
+          name: r'uuid',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {
+    r'MemoryEmbedding': MemoryEmbeddingSchema,
+    r'Degree': DegreeSchema
+  },
+  getId: _memoryNodeGetId,
+  getLinks: _memoryNodeGetLinks,
+  attach: _memoryNodeAttach,
+  version: '3.1.0+1',
+);
+
+int _memoryNodeEstimateSize(
+  MemoryNode object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.content.length * 3;
+  {
+    final value = object.degree;
+    if (value != null) {
+      bytesCount +=
+          3 + DegreeSchema.estimateSize(value, allOffsets[Degree]!, allOffsets);
+    }
+  }
+  {
+    final value = object.deviceId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.embedding;
+    if (value != null) {
+      bytesCount += 3 +
+          MemoryEmbeddingSchema.estimateSize(
+              value, allOffsets[MemoryEmbedding]!, allOffsets);
+    }
+  }
+  {
+    final value = object.type;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.uuid;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.version;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _memoryNodeSerialize(
+  MemoryNode object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeLong(offsets[0], object.accessCount);
+  writer.writeString(offsets[1], object.content);
+  writer.writeDateTime(offsets[2], object.createdAt);
+  writer.writeObject<Degree>(
+    offsets[3],
+    allOffsets,
+    DegreeSchema.serialize,
+    object.degree,
+  );
+  writer.writeString(offsets[4], object.deviceId);
+  writer.writeObject<MemoryEmbedding>(
+    offsets[5],
+    allOffsets,
+    MemoryEmbeddingSchema.serialize,
+    object.embedding,
+  );
+  writer.writeBool(offsets[6], object.isDeleted);
+  writer.writeLong(offsets[7], object.layer);
+  writer.writeDateTime(offsets[8], object.modifiedAt);
+  writer.writeString(offsets[9], object.type);
+  writer.writeDateTime(offsets[10], object.updatedAt);
+  writer.writeString(offsets[11], object.uuid);
+  writer.writeString(offsets[12], object.version);
+}
+
+MemoryNode _memoryNodeDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = MemoryNode(
+    accessCount: reader.readLongOrNull(offsets[0]) ?? 0,
+    content: reader.readString(offsets[1]),
+    createdAt: reader.readDateTimeOrNull(offsets[2]),
+    degree: reader.readObjectOrNull<Degree>(
+      offsets[3],
+      DegreeSchema.deserialize,
+      allOffsets,
+    ),
+    deviceId: reader.readStringOrNull(offsets[4]),
+    embedding: reader.readObjectOrNull<MemoryEmbedding>(
+      offsets[5],
+      MemoryEmbeddingSchema.deserialize,
+      allOffsets,
+    ),
+    isDeleted: reader.readBoolOrNull(offsets[6]) ?? false,
+    layer: reader.readLongOrNull(offsets[7]) ?? 0,
+    modifiedAt: reader.readDateTimeOrNull(offsets[8]),
+    type: reader.readStringOrNull(offsets[9]),
+    updatedAt: reader.readDateTimeOrNull(offsets[10]),
+    uuid: reader.readStringOrNull(offsets[11]),
+    version: reader.readStringOrNull(offsets[12]),
+  );
+  object.id = id;
+  return object;
+}
+
+P _memoryNodeDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 3:
+      return (reader.readObjectOrNull<Degree>(
+        offset,
+        DegreeSchema.deserialize,
+        allOffsets,
+      )) as P;
+    case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (reader.readObjectOrNull<MemoryEmbedding>(
+        offset,
+        MemoryEmbeddingSchema.deserialize,
+        allOffsets,
+      )) as P;
+    case 6:
+      return (reader.readBoolOrNull(offset) ?? false) as P;
+    case 7:
+      return (reader.readLongOrNull(offset) ?? 0) as P;
+    case 8:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 9:
+      return (reader.readStringOrNull(offset)) as P;
+    case 10:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 11:
+      return (reader.readStringOrNull(offset)) as P;
+    case 12:
+      return (reader.readStringOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _memoryNodeGetId(MemoryNode object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _memoryNodeGetLinks(MemoryNode object) {
+  return [];
+}
+
+void _memoryNodeAttach(IsarCollection<dynamic> col, Id id, MemoryNode object) {
+  object.id = id;
+}
+
+extension MemoryNodeByIndex on IsarCollection<MemoryNode> {
+  Future<MemoryNode?> getByUuid(String? uuid) {
+    return getByIndex(r'uuid', [uuid]);
+  }
+
+  MemoryNode? getByUuidSync(String? uuid) {
+    return getByIndexSync(r'uuid', [uuid]);
+  }
+
+  Future<bool> deleteByUuid(String? uuid) {
+    return deleteByIndex(r'uuid', [uuid]);
+  }
+
+  bool deleteByUuidSync(String? uuid) {
+    return deleteByIndexSync(r'uuid', [uuid]);
+  }
+
+  Future<List<MemoryNode?>> getAllByUuid(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return getAllByIndex(r'uuid', values);
+  }
+
+  List<MemoryNode?> getAllByUuidSync(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'uuid', values);
+  }
+
+  Future<int> deleteAllByUuid(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'uuid', values);
+  }
+
+  int deleteAllByUuidSync(List<String?> uuidValues) {
+    final values = uuidValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'uuid', values);
+  }
+
+  Future<Id> putByUuid(MemoryNode object) {
+    return putByIndex(r'uuid', object);
+  }
+
+  Id putByUuidSync(MemoryNode object, {bool saveLinks = true}) {
+    return putByIndexSync(r'uuid', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByUuid(List<MemoryNode> objects) {
+    return putAllByIndex(r'uuid', objects);
+  }
+
+  List<Id> putAllByUuidSync(List<MemoryNode> objects, {bool saveLinks = true}) {
+    return putAllByIndexSync(r'uuid', objects, saveLinks: saveLinks);
+  }
+}
+
+extension MemoryNodeQueryWhereSort
+    on QueryBuilder<MemoryNode, MemoryNode, QWhere> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension MemoryNodeQueryWhere
+    on QueryBuilder<MemoryNode, MemoryNode, QWhereClause> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> uuidIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uuid',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> uuidIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'uuid',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> uuidEqualTo(
+      String? uuid) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'uuid',
+        value: [uuid],
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterWhereClause> uuidNotEqualTo(
+      String? uuid) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [],
+              upper: [uuid],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [uuid],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [uuid],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'uuid',
+              lower: [],
+              upper: [uuid],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension MemoryNodeQueryFilter
+    on QueryBuilder<MemoryNode, MemoryNode, QFilterCondition> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      accessCountEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'accessCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      accessCountGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'accessCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      accessCountLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'accessCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      accessCountBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'accessCount',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      contentGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'content',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'content',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'content',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> contentIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'content',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      contentIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'content',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      createdAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'createdAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      createdAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'createdAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> createdAtEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      createdAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> createdAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> createdAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> degreeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'degree',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      degreeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'degree',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'deviceId',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      deviceIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'deviceId',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      deviceIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'deviceId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      deviceIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'deviceId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> deviceIdMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'deviceId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      deviceIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'deviceId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      deviceIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'deviceId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      embeddingIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'embedding',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      embeddingIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'embedding',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> isDeletedEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isDeleted',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> layerEqualTo(
+      int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'layer',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> layerGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'layer',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> layerLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'layer',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> layerBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'layer',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      modifiedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'modifiedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      modifiedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'modifiedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> modifiedAtEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      modifiedAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      modifiedAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'modifiedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> modifiedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'modifiedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'type',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'type',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'type',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'type',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'type',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> typeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'type',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      updatedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'updatedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      updatedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'updatedAt',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> updatedAtEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      updatedAtGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> updatedAtLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'updatedAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> updatedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'updatedAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'uuid',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'uuid',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'uuid',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'uuid',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'uuid',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'uuid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> uuidIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'uuid',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'version',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      versionIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'version',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      versionGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'version',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'version',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'version',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> versionIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'version',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition>
+      versionIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'version',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension MemoryNodeQueryObject
+    on QueryBuilder<MemoryNode, MemoryNode, QFilterCondition> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> degree(
+      FilterQuery<Degree> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'degree');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterFilterCondition> embedding(
+      FilterQuery<MemoryEmbedding> q) {
+    return QueryBuilder.apply(this, (query) {
+      return query.object(q, r'embedding');
+    });
+  }
+}
+
+extension MemoryNodeQueryLinks
+    on QueryBuilder<MemoryNode, MemoryNode, QFilterCondition> {}
+
+extension MemoryNodeQuerySortBy
+    on QueryBuilder<MemoryNode, MemoryNode, QSortBy> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByAccessCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'accessCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByAccessCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'accessCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByContent() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'content', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByContentDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'content', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByIsDeletedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByLayer() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'layer', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByLayerDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'layer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByUuid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByUuidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByVersion() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> sortByVersionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.desc);
+    });
+  }
+}
+
+extension MemoryNodeQuerySortThenBy
+    on QueryBuilder<MemoryNode, MemoryNode, QSortThenBy> {
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByAccessCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'accessCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByAccessCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'accessCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByContent() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'content', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByContentDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'content', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByDeviceId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByDeviceIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'deviceId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByIsDeletedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isDeleted', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByLayer() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'layer', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByLayerDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'layer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByModifiedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modifiedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByUpdatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'updatedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByUuid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByUuidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'uuid', Sort.desc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByVersion() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.asc);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QAfterSortBy> thenByVersionDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'version', Sort.desc);
+    });
+  }
+}
+
+extension MemoryNodeQueryWhereDistinct
+    on QueryBuilder<MemoryNode, MemoryNode, QDistinct> {
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByAccessCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'accessCount');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByContent(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'content', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByDeviceId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'deviceId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByIsDeleted() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isDeleted');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByLayer() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'layer');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByModifiedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByType(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'type', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByUpdatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'updatedAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByUuid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'uuid', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryNode, QDistinct> distinctByVersion(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'version', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension MemoryNodeQueryProperty
+    on QueryBuilder<MemoryNode, MemoryNode, QQueryProperty> {
+  QueryBuilder<MemoryNode, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<MemoryNode, int, QQueryOperations> accessCountProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'accessCount');
+    });
+  }
+
+  QueryBuilder<MemoryNode, String, QQueryOperations> contentProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'content');
+    });
+  }
+
+  QueryBuilder<MemoryNode, DateTime?, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, Degree?, QQueryOperations> degreeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'degree');
+    });
+  }
+
+  QueryBuilder<MemoryNode, String?, QQueryOperations> deviceIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'deviceId');
+    });
+  }
+
+  QueryBuilder<MemoryNode, MemoryEmbedding?, QQueryOperations>
+      embeddingProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'embedding');
+    });
+  }
+
+  QueryBuilder<MemoryNode, bool, QQueryOperations> isDeletedProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isDeleted');
+    });
+  }
+
+  QueryBuilder<MemoryNode, int, QQueryOperations> layerProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'layer');
+    });
+  }
+
+  QueryBuilder<MemoryNode, DateTime?, QQueryOperations> modifiedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'modifiedAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, String?, QQueryOperations> typeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'type');
+    });
+  }
+
+  QueryBuilder<MemoryNode, DateTime?, QQueryOperations> updatedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'updatedAt');
+    });
+  }
+
+  QueryBuilder<MemoryNode, String?, QQueryOperations> uuidProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'uuid');
+    });
+  }
+
+  QueryBuilder<MemoryNode, String?, QQueryOperations> versionProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'version');
+    });
+  }
+}
+
+// **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
@@ -24,9 +2120,9 @@ MemoryNode _$MemoryNodeFromJson(Map<String, dynamic> json) => MemoryNode(
       modifiedAt: json['modifiedAt'] == null
           ? null
           : DateTime.parse(json['modifiedAt'] as String),
-      layer: (json['layer'] as num?)?.toInt() ?? 0,
+      layer: json['layer'] as int? ?? 0,
       uuid: json['uuid'] as String?,
-      accessCount: (json['accessCount'] as num?)?.toInt() ?? 0,
+      accessCount: json['accessCount'] as int? ?? 0,
       createdAt: json['createdAt'] == null
           ? null
           : DateTime.parse(json['createdAt'] as String),
@@ -37,7 +2133,7 @@ Map<String, dynamic> _$MemoryNodeToJson(MemoryNode instance) =>
       'uuid': instance.uuid,
       'content': instance.content,
       'type': instance.type,
-      'createdAt': instance.createdAt.toIso8601String(),
+      'createdAt': instance.createdAt?.toIso8601String(),
       'updatedAt': instance.updatedAt?.toIso8601String(),
       'accessCount': instance.accessCount,
       'modifiedAt': instance.modifiedAt?.toIso8601String(),


### PR DESCRIPTION
This submission completes the agent memory demo app in `example/main.dart` showcasing Graph CRUD, SessionContext, QueryRouter, MemoryPipeline, and Re-ranking strategies. It also fixes Isar generator constructor parameter/field mismatches for `uuid` and `createdAt` in `MemoryNode` and `MemoryEdge`, and contains the newly generated Isar schemas.

Fixes #63

---
*PR created automatically by Jules for task [16316777073097948370](https://jules.google.com/task/16316777073097948370) started by @iberi22*