### PR TITLE
fix: resolve dart analyzer errors blocking CI

### DIFF
--- a/lib/src/memory_maintenance.dart
+++ b/lib/src/memory_maintenance.dart
@@ -1,5 +1,7 @@
 import 'memory_graph.dart';
 import 'models/memory_edge.dart';
+import 'models/memory_node.dart';
+import 'package:isar/isar.dart';
 
 /// Summary of a maintenance operation.
 class MemoryMaintenanceSummary {
@@ -59,7 +61,7 @@ class MemoryMaintenanceService {
 
     for (final node in allNodes) {
       if (type != null && node.type != type) continue;
-      if (node.createdAt.isBefore(cutoff)) {
+      if (node.createdAt != null && node.createdAt!.isBefore(cutoff)) {
         if (await graph.deleteNode(node.id)) removed++;
       }
     }
@@ -84,8 +86,9 @@ class MemoryMaintenanceService {
       return const MemoryMaintenanceSummary();
     }
 
-    // Sort oldest first
-    allNodes.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    // Sort oldest first (null createdAt treated as oldest)
+    allNodes.sort((a, b) => (a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0))
+        .compareTo(b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0)));
     final toRemove = allNodes.take(allNodes.length - maxEntries);
     int removed = 0;
 

--- a/lib/src/session_context.dart
+++ b/lib/src/session_context.dart
@@ -21,6 +21,7 @@ library;
 import 'memory_graph.dart';
 import 'models/memory_node.dart';
 import 'models/memory_edge.dart';
+import 'package:isar/isar.dart';
 
 /// Scoped memory context for a single session or user.
 ///


### PR DESCRIPTION
## Problem
CI Pipeline fails on main with exit code 3 from `dart analyze`:
- `undefined_getter`: memoryNodes not in scope (missing isar import)
- `undefined_method`: findAll not in scope (QueryExecute extension needs isar import)
- `unchecked_use_of_nullable_value`: createdAt is DateTime? but used as non-null

## Fix
- Add `import 'package:isar/isar.dart'` to memory_maintenance.dart + session_context.dart
- Null-safe handling of createdAt (isBefore guard + sort with epoch fallback)

## Result
`dart analyze lib/` → 0 errors (4 pre-existing warnings/info remain)

Closes: unblocks 3 dependabot PRs blocked by this pre-existing CI failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory cleanup handling for items without creation timestamps.
  - Updated retention sorting so undated items are processed consistently.
- **Reliability**
  - Improved session context support for database-backed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->